### PR TITLE
Minor fix to user links on the team daily page for sub-directory deployments of Phproject.

### DIFF
--- a/view/td_dashboard.html
+++ b/view/td_dashboard.html
@@ -69,8 +69,8 @@
 						<div class="col-md-4 text-center">
 							<div class="panel panel-{{ @item.status | esc }} panel-scores">
 								<div class="panel-heading">
-									<a href="/user/{{ @item.username | esc }}"><img src="{{ @item.avatar | esc }}" srcset="{{ @item.avatar2x | esc }} 2x" class="img-rounded profile-picture" alt></a>
-									<h3 class="uname"><a href="/user/{{ @item.username | esc }}">{{@item.name}}</a></h3>
+									<a href="{{ @BASE }}/user/{{ @item.username | esc }}"><img src="{{ @item.avatar | esc }}" srcset="{{ @item.avatar2x | esc }} 2x" class="img-rounded profile-picture" alt></a>
+									<h3 class="uname"><a href="{{ @BASE }}/user/{{ @item.username | esc }}">{{@item.name}}</a></h3>
 								</div>
 								<div class="panel-body text-center">
 									<p><strong><div class="row">


### PR DESCRIPTION
I deployed a copy of Phproject to a sub-directory, and spotted with teamdaily installed that the user links were broken. This fix should resolve the issue without affecting regular deployments on the root-level of a site.